### PR TITLE
Use Ubuntu 2404 in CI pipelines

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: Test
 agent:
   machine:
-    type: e1-standard-2
+    type: e2-standard-2
     os_image: ubuntu2404
 blocks:
   - name: Test

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -3,7 +3,7 @@ name: Test
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu2004
+    os_image: ubuntu2404
 blocks:
   - name: Test
     task:


### PR DESCRIPTION
This replaces usage of ubuntu2004 with ubuntu2404 in CI pipelines.