### PR TITLE
Update to Go 1.25

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -10,7 +10,7 @@ blocks:
       prologue:
         commands:
           - checkout
-          - sem-version go 1.22
+          - sem-version go 1.25
           - go get ./...
           - go install gotest.tools/gotestsum@v1.7.0
       jobs:

--- a/example_test.go
+++ b/example_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
 )
 
-func ExampleSimple() {
+func SimpleExample() {
 	logger := &StdLogger{log.New(os.Stdout, "", log.LstdFlags)}
 	cfg, _ := config.LoadDefaultConfig(context.TODO())
 	client := kinesis.NewFromConfig(cfg)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Countingup/kinesis-producer
 
-go 1.22
+go 1.25
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.30.5


### PR DESCRIPTION
Rename test case as otherwise `go test` expects a `Simple` function to exist (https://go.dev/blog/examples)
